### PR TITLE
Fixed playback seek callback invocation

### DIFF
--- a/foo_dotnet_component_host/fb2k/play_callback.cpp
+++ b/foo_dotnet_component_host/fb2k/play_callback.cpp
@@ -51,7 +51,7 @@ void PlayCallbackImpl::on_playback_starting( play_control::t_track_command p_com
 
 void PlayCallbackImpl::on_playback_seek( double p_time )
 {
-    parent_->OnTrackPlaybackPositionChanged( p_time );
+    parent_->OnTrackSeekPerformed( p_time );
 }
 
 void PlayCallbackImpl::on_playback_edited( metadb_handle_ptr p_track )


### PR DESCRIPTION
The `TrackSeekPerformed` callback from `IPlaybackCallbacks` was never invoked. Found that it was because a wrong interface method was being called instead.